### PR TITLE
Move footer into React app with version from meta tag

### DIFF
--- a/compact.html
+++ b/compact.html
@@ -3,14 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="app-version" content="@APP-VERSION@" />
     <title>Contribution Tracker</title>
   </head>
   <body class="compact">
     <div id="root"></div>
-    <footer>
-      <a href="https://github.com/danielparks/contributions-tracker"
-      >github.com/danielparks/contributions-tracker</a> • @APP-VERSION@
-    </footer>
     <script type="module" src="/src/compact.tsx"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,14 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="app-version" content="@APP-VERSION@" />
     <title>Contribution Tracker</title>
   </head>
   <body>
     <div id="root"></div>
-    <footer>
-      <a href="https://github.com/danielparks/contributions-tracker"
-      >github.com/danielparks/contributions-tracker</a> • @APP-VERSION@
-    </footer>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import {
 } from "./github/api.ts";
 import { Calendar } from "./model.ts";
 import { ContributionsView } from "./components/ContributionsView.tsx";
+import { Footer } from "./components/Footer.tsx";
+import { getAppVersion } from "./version.ts";
 
 function getAuthCode() {
   const code = new URLSearchParams(location.search).get("code");
@@ -224,6 +226,7 @@ export default function App({ username }: { username: string | null }) {
       {calendar
         ? <ContributionsView calendar={calendar} />
         : <div className="info-message">No contributions data</div>}
+      <Footer version={getAppVersion()} />
     </>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,10 @@
+export function Footer({ version }: { version: string }) {
+  return (
+    <footer>
+      <a href="https://github.com/danielparks/contributions-tracker">
+        github.com/danielparks/contributions-tracker
+      </a>{" "}
+      • {version}
+    </footer>
+  );
+}

--- a/src/static.tsx
+++ b/src/static.tsx
@@ -2,9 +2,11 @@ import "./App.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import ErrorBoundary from "./components/ErrorBoundary.tsx";
+import { Footer } from "./components/Footer.tsx";
 import { ContributionsView } from "./components/ContributionsView.tsx";
 import { StatusMessage } from "./components/StatusMessage.tsx";
 import { useStaticCalendar } from "./hooks/useStaticCalendar.ts";
+import { getAppVersion } from "./version.ts";
 
 export function StaticApp() {
   const { calendar, error, loading } = useStaticCalendar();
@@ -41,6 +43,7 @@ export function StaticApp() {
         <h1>Contribution Graph for {calendar.name}</h1>
       </header>
       <ContributionsView calendar={calendar} />
+      <Footer version={getAppVersion()} />
     </>
   );
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,4 @@
+export function getAppVersion(): string {
+  const meta = document.querySelector('meta[name="app-version"]');
+  return meta?.getAttribute("content") || "unknown";
+}

--- a/static.html
+++ b/static.html
@@ -3,14 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="app-version" content="@APP-VERSION@" />
     <title>Contribution Tracker</title>
   </head>
   <body>
     <div id="root"></div>
-    <footer>
-      <a href="https://github.com/danielparks/contributions-tracker"
-      >github.com/danielparks/contributions-tracker</a> • @APP-VERSION@
-    </footer>
     <script type="module" src="/src/static.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
The footer is now rendered by the React app instead of being in the HTML
files. The version is injected into a meta tag by the Vite plugin and read
by the React app using getAppVersion(). This makes the version available
to the React app for display and future use (e.g., displaying metadata like
last fetch time).

The compact app does not display the footer but has the version in the HTML
source for debugging purposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
