### PR TITLE
Refactor ContributionsGraph to use divs instead of table elements.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -131,20 +131,20 @@ button.logout-button:hover {
   margin: 10px 0;
 }
 
-table.contributions {
+.contributions-graph {
   display: block;
 }
 
-table.contributions > tbody {
+.contributions-graph > .weeks {
   display: flex;
 }
 
-table.contributions > tbody > tr {
+.contributions-graph > .weeks > .week {
   display: block;
   flex: 1;
 }
 
-table.contributions > tbody > tr > td {
+.contributions-graph > .weeks > .week > div {
   display: block;
   position: relative;
   text-align: center;
@@ -153,23 +153,23 @@ table.contributions > tbody > tr > td {
   aspect-ratio: 1/1;
 }
 
-table.contributions > tbody > tr > td.unknown > ol {
+.contributions-graph > .weeks > .week > div.unknown > ol {
   filter: blur(1px);
 }
 
-table.contributions > tbody > tr > td.unknown > ol {
+.contributions-graph > .weeks > .week > div.unknown > ol {
   border: 1px solid #fff;
 }
 
-table.contributions > tbody > tr > td.empty > ol {
+.contributions-graph > .weeks > .week > div.empty > ol {
   border: 1px solid #eee;
 }
 
-table.contributions > tbody > tr > td.highlight > ol {
+.contributions-graph > .weeks > .week > div.highlight > ol {
   border: 1px solid hsl(30deg 100% 50%);
 }
 
-table.contributions > tbody > tr > td > ol {
+.contributions-graph > .weeks > .week > div > ol {
   display: flex;
   list-style: none;
   margin: 0;
@@ -178,7 +178,7 @@ table.contributions > tbody > tr > td > ol {
   box-sizing: border-box;
 }
 
-table.contributions > tbody > tr > td > ol > li {
+.contributions-graph > .weeks > .week > div > ol > li {
   margin: 0;
   padding: 0;
   height: 100%;

--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -97,7 +97,8 @@ describe("App smoke test", () => {
         screen.getByText(`Contribution Graph for ${name}`),
       ).toBeInTheDocument();
 
-      expect(document.querySelector("table.contributions")).toBeInTheDocument();
+      expect(document.querySelector(".contributions-graph"))
+        .toBeInTheDocument();
     }, { timeout: 500 });
 
     await waitFor(() => {

--- a/src/components/ContributionsGraph.tsx
+++ b/src/components/ContributionsGraph.tsx
@@ -33,14 +33,14 @@ export function ContributionsGraph(
     : undefined;
 
   return (
-    <table
-      className="contributions"
+    <div
+      className="contributions-graph"
       onClick={handleClick}
       style={clickUrl ? { cursor: "pointer" } : undefined}
     >
-      <tbody>
+      <div className="weeks">
         {[...calendar.weeks()].map((week) => (
-          <tr key={`week ${week[0].date}`} className="week">
+          <div key={`week ${week[0].date}`} className="week">
             {week.map((day) => (
               <GraphDay
                 key={day.date.toString()}
@@ -51,10 +51,10 @@ export function ContributionsGraph(
                 showTooltip={showTooltip}
               />
             ))}
-          </tr>
+          </div>
         ))}
-      </tbody>
-    </table>
+      </div>
+    </div>
   );
 }
 
@@ -127,12 +127,12 @@ export function GraphDay(
   }
 
   return (
-    <td style={style} className={className.join(" ")}>
+    <div style={style} className={className.join(" ")}>
       {showTooltip && <DayInfo day={day} />}
       <ol>
         {subdivisions.map(({ key, style }) => <li key={key} style={style} />)}
       </ol>
-    </td>
+    </div>
   );
 }
 
@@ -148,7 +148,7 @@ function DayInfo({ day }: { day: Day }) {
   useEffect(() => {
     function checkOverflow() {
       if (divRef.current && divRef.current.parentNode) {
-        const rect = (divRef.current.parentNode as HTMLTableCellElement)
+        const rect = (divRef.current.parentNode as HTMLDivElement)
           .getBoundingClientRect();
         const newClassNames = ["day-info", "align-top"];
         // FIXME: this assumes the window is large enough.


### PR DESCRIPTION
The previous implementation used <table>/<tr>/<td> elements but displayed
them as vertical columns using CSS (with display: flex on tbody). This was
confusing since <tr> elements appeared as columns, not rows.

Changed to use semantic div elements with descriptive class names:
- .contributions-graph (container)
- .weeks (flex container)
- .week (each vertical column)
- Individual day divs

This makes the HTML structure match the visual layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
