### PR TITLE
Switch to +nightly for `rust fmt`

### DIFF
--- a/.github/workflows/pr-checks-rust.yaml
+++ b/.github/workflows/pr-checks-rust.yaml
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
+          toolchain: nightly
           components: rustfmt
       - uses: actions-rust-lang/rustfmt@v1
 

--- a/backend/.pre-commit-config.yaml
+++ b/backend/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: cargo fmt
         name: cargo fmt
         language: system
-        entry: cargo fmt --check
+        entry: cargo +nightly fmt --check
         files: (\.rs|rustfmt\.toml)$
         pass_filenames: false
         priority: 0

--- a/backend/rustfmt.toml
+++ b/backend/rustfmt.toml
@@ -2,3 +2,6 @@ max_width = 80
 newline_style = "Unix"
 struct_lit_width = 60
 use_field_init_shorthand = true
+
+unstable_features = true
+wrap_comments = true

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -60,7 +60,8 @@ fn cli(params: &Params) -> anyhow::Result<ExitCode> {
 /// Generate `OpenAPI` specification.
 ///
 /// Uses the trait-based API stub to generate the spec without requiring
-/// an implementation. This is much faster than compiling the full implementation.
+/// an implementation. This is much faster than compiling the full
+/// implementation.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
This allows us to enable wrapping comments.
