### PR TITLE
Fix API client backend URL handling

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -14,8 +14,11 @@ import Api from "./Api.ts";
  * proxy that forwards `/api` to the backend on port 3000.
  */
 export const api = new Api({
-  host: import.meta.env.VITE_BACKEND_URL || import.meta.env.VITE_FRONTEND_URL ||
-    "",
+  // Remove trailing slash since Api client just appends the path, which always
+  // starts with a /.
+  host: (import.meta.env.VITE_BACKEND_URL ||
+    import.meta.env.VITE_FRONTEND_URL ||
+    "").replace(/\/+$/, ""),
 });
 
 /**


### PR DESCRIPTION
The API client just appends the path to the “host”, which causes a
double slash if the backend URL ends with a slash. This strips it before
passing it to the API client.
