### PR TITLE
`SummaryBox`: show correct calendar date range

### DIFF
--- a/src/components/SummaryBox.tsx
+++ b/src/components/SummaryBox.tsx
@@ -40,11 +40,10 @@ function YearSummary(
   const filtered = calendar.repositories.size -
     calendar.filteredRepos(filter).length;
 
-  // Get the date range (FIXME handle partial weeks)
-  const firstDay = calendar.days[0]?.date;
-  const lastDay = calendar.days[calendar.days.length - 1]?.date;
-  const dateRange = firstDay && lastDay
-    ? `${DATE_FORMATTER.format(firstDay)} – ${DATE_FORMATTER.format(lastDay)}`
+  const firstDate = calendar.firstDay()?.date;
+  const lastDate = calendar.lastDay()?.date;
+  const dateRange = firstDate && lastDate
+    ? `${DATE_FORMATTER.format(firstDate)} – ${DATE_FORMATTER.format(lastDate)}`
     : "";
 
   // Segment contributions for each repo for sparklines.

--- a/src/model/Calendar.ts
+++ b/src/model/Calendar.ts
@@ -348,6 +348,20 @@ export class Calendar {
   }
 
   /**
+   * Get the first day in the calendar with data.
+   */
+  firstDay(): Day | undefined {
+    return this.days.find((day) => day.hasData());
+  }
+
+  /**
+   * Get the last day in the calendar with data.
+   */
+  lastDay(): Day | undefined {
+    return this.days.findLast((day) => day.hasData());
+  }
+
+  /**
    * Yields weeks (7-day arrays) of Days, starting on Sunday.
    */
   *weeks() {

--- a/src/model/Day.ts
+++ b/src/model/Day.ts
@@ -22,6 +22,18 @@ export class Day {
   }
 
   /**
+   * Do we have data about this day?
+   *
+   * The day doesn’t necessarily need to have any contributions; it just needs
+   * to have been included in query results.
+   */
+  hasData() {
+    // FIXME knownContributionCount is inefficient
+    return this.contributionCount !== null ||
+      this.knownContributionCount() > 0;
+  }
+
+  /**
    * Sums up the contributions we know about from specific repositories.
    */
   knownContributionCount() {


### PR DESCRIPTION
Previously the date range displayed was always the Sunday of the first
week and the Saturday of the last week. This changes it to be the first
and last dates we have data for.
