### PR TITLE
Release 0.7.0: include local contributions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 
 [[package]]
 name = "repoyear-backend"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert2",

--- a/README.md
+++ b/README.md
@@ -94,10 +94,6 @@ This is a TypeScript and React app with a simple Rust backend built on
 [Dropshot]. Dropshot provides automatic OpenAPI support, which enables
 compile-time type checking of calls across the API boundary.
 
-## To do
-
-- [ ] Load information about local repositories in backend.
-
 ### Likely incompatible
 
 - **Systemd socket activation.** Dropshot takes a `SocketAddr` as configuration

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "repoyear-backend"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Daniel Parks <oss-repoyear@demonhorse.org>"]
 description = ""
 homepage = "https://github.com/danielparks/repoyear"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "repoyear",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "dev": "npm run generate:api:watch & vite",

--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -75,7 +75,7 @@ export interface ApiConfig {
        * Pulled from info.version in the OpenAPI schema. Sent in the
        * `api-version` header on all requests.
        */
-      apiVersion = "0.6.0";
+      apiVersion = "0.7.0";
 
       constructor({ host = "", baseParams = {}, token }: ApiConfig = {}) {
         this.host = host;

--- a/src/api/openapi.json
+++ b/src/api/openapi.json
@@ -114,7 +114,7 @@
   },
   "info": {
     "title": "RepoYear API",
-    "version": "0.6.0"
+    "version": "0.7.0"
   },
   "openapi": "3.0.3",
   "paths": {


### PR DESCRIPTION
  * Now able to scan and visualize contributions on local repositories.
  * GitHub authorization now allows collecting data about private repos.
  * Significant UI improvements.
