### PR TITLE
Fix Dependabot PR updater: push with custom token

### DIFF
--- a/.github/workflows/dependabot-prek.yaml
+++ b/.github/workflows/dependabot-prek.yaml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ secrets.PUSH_TOKEN }}
       - uses: taiki-e/install-action@v2
         with:
           tool: prek


### PR DESCRIPTION
This causes the pushed commit to trigger the PR check workflow again.
