### PR TITLE
Treat unknown contributions as their own repo

### DIFF
--- a/src/components/RepositoryList.tsx
+++ b/src/components/RepositoryList.tsx
@@ -72,8 +72,11 @@ export function RepositoryName({ repo }: { repo: Repository }) {
   } else if (repo.url.startsWith("local:")) {
     const name = repo.url.slice("local:".length);
     return <span style={{ color: repo.color() }}>{name}</span>;
-  } else {
+  } else if (repo.url.startsWith("http:") || repo.url.startsWith("https:")) {
     // I don’t think there’s any way to get here.
     return <a style={{ color: repo.color() }} href={repo.url}>{repo.url}</a>;
+  } else {
+    // could be "unknown"
+    return <span style={{ color: repo.color() }}>{repo.url}</span>;
   }
 }

--- a/src/components/SummaryBox.tsx
+++ b/src/components/SummaryBox.tsx
@@ -261,11 +261,6 @@ function DaySummary({ day, filter }: { day: Day; filter: Filter }) {
           </ol>
         </>
       )}
-      {day.unknownCount() > 0 && (
-        <p className="message unknown-contributions">
-          {countNoun(day.unknownCount(), "contribution")} from unknown sources
-        </p>
-      )}
     </div>
   );
 }

--- a/src/model/Calendar.ts
+++ b/src/model/Calendar.ts
@@ -164,15 +164,33 @@ export class Calendar {
    * Calculate the total number of contributions for each repository.
    */
   updateRepoCounts() {
+    let unknownTotal = 0;
+
     for (const repo of this.repositories.values()) {
       repo.contributions = 0;
     }
 
     this.days.forEach((day) => {
+      let dayTotal = 0;
       day.repositories.forEach((repoDay) => {
-        repoDay.repository.contributions += repoDay.count();
+        if (repoDay.repository.url != "unknown") {
+          const count = repoDay.count();
+          dayTotal += count;
+          repoDay.repository.contributions += count;
+        }
       });
+
+      const unknownCount = (day.contributionCount || 0) - dayTotal;
+      if (unknownCount > 0) {
+        unknownTotal += unknownCount;
+        day.setRepoCommits(this.internRepository("unknown"), unknownCount);
+      }
     });
+
+    const unknownRepo = this.repositories.get("unknown");
+    if (unknownRepo) {
+      unknownRepo.contributions = unknownTotal;
+    }
   }
 
   /**

--- a/src/model/Repository.ts
+++ b/src/model/Repository.ts
@@ -46,6 +46,9 @@ export class Repository {
    * string for this repository.
    */
   color(lightness = 55, chroma = 0.2) {
+    if (this.url === "unknown") {
+      return `oklch(${lightness}% 0 0deg)`;
+    }
     return `oklch(${lightness}% ${chroma} ${this.hue}deg)`;
   }
 }


### PR DESCRIPTION
This is useful when there are lots of contributions to private repos,
which all show up as unknown.
