### PR TITLE
Change label on unknown contributions in summary box

### DIFF
--- a/src/components/SummaryBox.tsx
+++ b/src/components/SummaryBox.tsx
@@ -231,6 +231,9 @@ function DaySummary({ day, filter }: { day: Day; filter: Filter }) {
                   )}
                 </h4>
                 <ul>
+                  {repoDay.unknownCount > 0 && (
+                    <li>{countNoun(repoDay.unknownCount, "contribution")}</li>
+                  )}
                   {repoDay.commitCount > 0 && (
                     <li>{countNoun(repoDay.commitCount, "commit")}</li>
                   )}

--- a/src/model/Calendar.ts
+++ b/src/model/Calendar.ts
@@ -256,10 +256,8 @@ export class Calendar {
             firstEpochDay = previousEpochDay;
           }
 
-          this.days[previousEpochDay - firstEpochDay]!.setRepoCommits(
-            repository,
-            commits,
-          );
+          this.days[previousEpochDay - firstEpochDay]!.forRepo(repository)
+            .setCommits(commits);
         }
       };
 
@@ -305,7 +303,7 @@ export class Calendar {
       const unknownCount = (day.contributionCount || 0) - dayTotal;
       if (unknownCount > 0) {
         unknownTotal += unknownCount;
-        day.setRepoCommits(this.internRepository("unknown"), unknownCount);
+        day.forRepo(this.internRepository("unknown")).setUnknowns(unknownCount);
       } else {
         day.repositories.delete("unknown");
       }

--- a/src/model/Day.ts
+++ b/src/model/Day.ts
@@ -55,7 +55,7 @@ export class Day {
    * commits to the "unknown" repository.
    */
   unknownCount() {
-    return this.repositories.get("unknown")?.commitCount ?? 0;
+    return this.repositories.get("unknown")?.unknownCount ?? 0;
   }
 
   /**
@@ -103,15 +103,17 @@ export class Day {
   }
 
   /**
-   * Set the commit count for a particularly repository.
+   * Get a RepositoryDay object for a particular repo.
+   *
+   * Creates the RepositoryDay object if it doesn’t exist.
    */
-  setRepoCommits(repository: Repository, count: number) {
+  forRepo(repository: Repository): RepositoryDay {
     let repoDay = this.repositories.get(repository.url);
     if (!repoDay) {
       repoDay = new RepositoryDay(repository);
       this.repositories.set(repository.url, repoDay);
     }
-    repoDay.commitCount = count;
+    return repoDay;
   }
 }
 
@@ -142,6 +144,8 @@ export class RepositoryDay {
   prs: Set<string> = new Set();
   /** PR review URLs */
   reviews: Set<string> = new Set();
+  /** Unknown contribution count */
+  unknownCount = 0;
 
   constructor(repository: Repository) {
     this.repository = repository;
@@ -176,6 +180,13 @@ export class RepositoryDay {
   }
 
   /**
+   * Record unknown contribution counts for this day.
+   */
+  setUnknowns(count: number) {
+    this.unknownCount = count;
+  }
+
+  /**
    * Returns the repository URL.
    */
   url() {
@@ -184,13 +195,9 @@ export class RepositoryDay {
 
   /**
    * Returns the contribution count for this repository on this day.
-   *
-   * This only includes “known” contributions for events that we track, like
-   * commits and PRs. The contribution count returned by the contribution
-   * calendar may include other contributions we don’t check for.
    */
   count() {
     return this.created + this.commitCount + this.issues.size + this.prs.size +
-      this.reviews.size;
+      this.reviews.size + this.unknownCount;
   }
 }


### PR DESCRIPTION
Previously unknown contributions appeared in the summary box under a
fake repo called “unknown”, but were listed as “commits.” They actually
can be any kind of GitHub contribution, so this changes the label to
“contributions” to be more accurate.
