### PR TITLE
GitHub release action: specify binary name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,7 @@ jobs:
     steps:
       - uses: danielparks/github-actions/create-release-artifacts@main
         with:
+          binary: repoyear-backend
           target: ${{ matrix.target }}
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: backend


### PR DESCRIPTION
The backend crate name is not the same as the repo name, so it has to be
explicitly specified.

Fixes: #125 Release workflow fails
