### PR TITLE
Add month labels to calendar

### DIFF
--- a/src/components/CalendarHeatMap.css
+++ b/src/components/CalendarHeatMap.css
@@ -1,7 +1,7 @@
 .calendar-heat-map {
   display: block;
   position: relative;
-  margin: 1rlh -1rlh;
+  margin: 1rlh -2rlh;
 }
 
 body.compact .calendar-heat-map {
@@ -26,11 +26,14 @@ body.compact .calendar-heat-map {
 .calendar-heat-map > .weeks {
   display: flex;
   overflow-x: auto;
+  padding: 0 1rlh;
 }
 
 .calendar-heat-map > .weeks > .week {
   display: block;
+  position: relative;
   flex: 1;
+  padding-top: 1lh;
 }
 
 .calendar-heat-map > .weeks > .week > div {
@@ -41,6 +44,28 @@ body.compact .calendar-heat-map {
   padding: 0;
   aspect-ratio: 1/1;
   min-height: 15px;
+}
+
+.calendar-heat-map > .weeks > .week > div.month {
+  display: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 1lh;
+  margin: 0;
+  padding: 0;
+}
+
+.calendar-heat-map > .weeks > .week.first > div.month {
+  display: block;
+  text-align: left;
+  font-size: 80%;
+  width: 100px;
+  color: #666;
+}
+
+.calendar-heat-map > .weeks > .week.first > div.month.january {
+  font-weight: bold;
 }
 
 .calendar-heat-map.loading > .weeks > .week > div.unknown > ol {

--- a/src/components/CalendarHeatMap.tsx
+++ b/src/components/CalendarHeatMap.tsx
@@ -1,6 +1,12 @@
 import "./CalendarHeatMap.css";
 import { Calendar, Day, Filter } from "../model/index.ts";
 
+const MONTH_FORMATTER = new Intl.DateTimeFormat(undefined, { month: "short" });
+const JANUARY_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "short",
+});
+
 export interface CalendarHeatMapProps {
   calendar: Calendar;
   filter?: Filter;
@@ -47,23 +53,35 @@ export function CalendarHeatMap(
       style={clickUrl ? { cursor: "pointer" } : undefined}
     >
       <div className="weeks" dir="rtl">
-        {[...calendar.weeks()].reverse().map((week) => (
-          <div key={`week ${week[0].date}`} className="week">
-            {week.map((day) => (
-              <GraphDay
-                key={day.date.toString()}
-                day={day}
-                filter={filter}
-                max={dayMax}
-                highlight={highlight}
-                selected={selectedDays.has(day)}
-                onClick={onDayClick}
-                onMouseDown={onDayMouseDown}
-                onMouseEnter={onDayMouseEnter}
-              />
-            ))}
-          </div>
-        ))}
+        {[...calendar.weeks()].reverse().map((week) => {
+          const saturday = week.at(-1)!.date;
+          const month = saturday.getMonth();
+          return (
+            <div
+              key={`week ${week[0].date}`}
+              className={`week ${saturday.getDate() <= 7 ? "first" : ""}`}
+            >
+              <div className={`month ${month === 0 ? "january" : ""}`}>
+                {(month === 0 ? JANUARY_FORMATTER : MONTH_FORMATTER).format(
+                  saturday,
+                )}
+              </div>
+              {week.map((day) => (
+                <GraphDay
+                  key={day.date.toString()}
+                  day={day}
+                  filter={filter}
+                  max={dayMax}
+                  highlight={highlight}
+                  selected={selectedDays.has(day)}
+                  onClick={onDayClick}
+                  onMouseDown={onDayMouseDown}
+                  onMouseEnter={onDayMouseEnter}
+                />
+              ))}
+            </div>
+          );
+        })}
       </div>
       {!calendar.hasData() && (loading
         ? <div className="message">Loading…</div>


### PR DESCRIPTION
Unfortunately, in order to have the month labels not clipped on the far right, I had to extend the container to the edges of the window. The scrollbar now looks kind of weird when it appears.

Fixes: #109 — Add month labels