### PR TITLE
Actually use previous contributions cache

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -23,11 +23,12 @@
     "npm:@vitejs/plugin-react@^5.1.4": "5.1.4_vite@7.3.1__@types+node@24.12.0_@types+node@24.12.0",
     "npm:@vitest/ui@^4.0.18": "4.0.18_vitest@4.0.18_@types+node@24.12.0_happy-dom@20.8.3",
     "npm:chokidar-cli@3": "3.0.0",
+    "npm:fast-deep-equal@^3.1.3": "3.1.3",
     "npm:globals@^16.5.0": "16.5.0",
     "npm:happy-dom@^20.8.3": "20.8.3",
     "npm:idb-keyval@^6.2.2": "6.2.2",
     "npm:react-dom@^19.2.4": "19.2.4_react@19.2.4",
-    "npm:react-error-boundary@^6.0.3": "6.0.3_react@19.2.3",
+    "npm:react-error-boundary@^6.0.3": "6.0.3_react@19.2.4",
     "npm:react@19.2.3": "19.2.3",
     "npm:react@^19.2.4": "19.2.4",
     "npm:typescript@^5.9.3": "5.9.3",
@@ -1885,6 +1886,9 @@
     "fast-content-type-parse@3.0.0": {
       "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="
     },
+    "fast-deep-equal@3.1.3": {
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
     "fast-glob@3.3.3": {
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dependencies": [
@@ -2471,7 +2475,7 @@
         "scheduler"
       ]
     },
-    "react-error-boundary@6.0.3_react@19.2.3": {
+    "react-error-boundary@6.0.3_react@19.2.4": {
       "integrity": "sha512-5guqn2UYpCFjE8UDMA8J7Kke+YSGBFrKQRJb3XdcaGZXYINZfQXgBt3ifY6MvjkN7QROc5A8zclyoSCwrcRUKw==",
       "dependencies": [
         "react@19.2.4"
@@ -3007,6 +3011,7 @@
         "npm:@vitejs/plugin-react@^5.1.4",
         "npm:@vitest/ui@^4.0.18",
         "npm:chokidar-cli@3",
+        "npm:fast-deep-equal@^3.1.3",
         "npm:globals@^16.5.0",
         "npm:happy-dom@^20.8.3",
         "npm:idb-keyval@^6.2.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@tanstack/react-query-persist-client": "^5.90.24",
     "@types/react": "^19.2.14",
     "@vitejs/plugin-react": "^5.1.4",
+    "fast-deep-equal": "^3.1.3",
     "idb-keyval": "^6.2.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { Icon } from "./components/Icon.tsx";
 import { getAppVersion } from "./version.ts";
 import { useTokenManager } from "./hooks/useTokenManager.ts";
 import { arrayStartsWith, sum } from "./util.ts";
+import equal from "fast-deep-equal";
 
 export default function App(
   {
@@ -171,7 +172,8 @@ export default function App(
     if (
       gitHub.length &&
       prev &&
-      prev.local === local &&
+      prev.gitHub.length > 0 &&
+      equal(prev.local, local) &&
       arrayStartsWith(gitHub, prev.gitHub)
     ) {
       // Possible updates from GitHub and local contributions haven’t changed.

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import equal from "fast-deep-equal";
+
 /**
  * Sum an array-like.
  */
@@ -28,8 +30,7 @@ export function chunk<T>(
  * Check if `array` starts with `prefix`.
  */
 export function arrayStartsWith<T>(array: T[], prefix: T[]): boolean {
-  return array.length >= prefix.length &&
-    prefix.every((e, i) => e === array[i]);
+  return equal(array.slice(0, prefix.length), prefix);
 }
 
 /**


### PR DESCRIPTION
Previously the code tried to compare arrays and objects with `===`,
which returned `false`. This switches to using fast-deep-equal.

This exposed a bug in the contribution caching logic — we need to ensure
that the cached calendar has GitHub contributions, otherwise the name
doesn’t get set on the calendar. (I think we could fix this by updating
the name later, but this is simpler for now.)

Claude found the caching logic bug and suggested fast-deep-equal, so:

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
