### PR TITLE
Claude reviews: use gh-pr-render to give context

### DIFF
--- a/.github/workflows/claude-pr-reviews.yaml
+++ b/.github/workflows/claude-pr-reviews.yaml
@@ -16,6 +16,15 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Render PR discussion
+        id: render
+        run: |
+          {
+            echo "pr_context<<EOF"
+            npx gh-pr-render ${{ github.repository }} ${{ github.event.pull_request.number }}
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - uses: anthropics/claude-code-action@v1
         with:
           # You can set either of these secrets. If both are set, the API key
@@ -26,13 +35,14 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            Please review this pull request. The PR branch is already checked out in the current working directory.
+            Please take a look at this this pull request. The PR branch is already checked out in the current working directory, and the PR discussion is included below. You may have already reviewed this; if not please review it. If you have reviewed it, please make sure your review is up-to-date.
 
-            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
+            - Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight new specific code issues.
+            - Use `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments/$ID/replies -X POST -f "body=$BODY"` to post replies to diff comments, replacing `$ID` with the id listed with the diff comment and `$BODY` with the body of your reply.
+            - Use `gh pr comment` for top-level feedback. Don’t repeat feedback there that you've already given elsewhere.
+            - Only post GitHub comments - don't submit review text as messages.
 
-            Use `gh pr comment` for top-level feedback. Don’t repeat feedback there that you’ve already given with an inline comment.
-
-            Only post GitHub comments - don't submit review text as messages.
+            ${{ steps.render.outputs.pr_context }}
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"


### PR DESCRIPTION
This uses my new tool, [gh-pr-render], to render the pull request
discussion so that Claude can avoid repeating itself.

[gh-pr-render]: https://github.com/danielparks/gh-pr-render
