### PR TITLE
Improvements to Claude PR reviews

### DIFF
--- a/.github/workflows/claude-pr-reviews.yaml
+++ b/.github/workflows/claude-pr-reviews.yaml
@@ -1,16 +1,58 @@
-name: Claude PR Review
+# DANGER: see the WARNINGs in this file before enabling this workflow.
+
+name: Claude
 on:
+  # Run on pull requests automatically.
   pull_request:
-    # Add synchronize to trigger reviews automatically when adding new commits.
+    # synchronize currently disabled for cost reasons.
     types: [opened, reopened, ready_for_review]
+
+  # WARNING: These triggers allow collaborators to ping @claude on third party
+  # PRs and issues without any other protection against prompt injection. If you
+  # do not trust your collaborators to be extremely careful, then disable all
+  # the triggers below.
+  issue_comment:
+    types: [created, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+  issues:
+    types: [opened, edited, assigned]
+  pull_request_review:
+    types: [submitted, edited]
 
 jobs:
   review:
+    # WARNING: This assumes that anybody who can assign issues is trusted.
+    if: |
+      (
+        contains(
+          fromJSON('["OWNER", "COLLABORATOR"]'),
+          github.event.pull_request.author_association ||
+          github.event.comment.author_association ||
+          github.event.review.author_association ||
+          github.event.issue.author_association
+        ) &&
+        (
+          github.event_name == 'pull_request' ||
+          contains(github.event.comment.body, '@claude') ||
+          contains(github.event.review.body, '@claude') ||
+          contains(github.event.issue.body, '@claude') ||
+          contains(github.event.issue.title, '@claude')
+        )
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        github.event.action == 'assigned' &&
+        github.event.assignee.login == 'claude[bot]'
+      )
     runs-on: ubuntu-latest
     permissions:
+      # contents: write is not safe without branch protection rules
       contents: read
       pull-requests: write
       id-token: write
+      issues: write
+      actions: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -20,13 +62,17 @@ jobs:
         id: render
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        # WARNING: gh-pr-render is not pinned to a version here
         run: |
           {
             echo "pr_context<<EOF"
-            npx gh-pr-render ${{ github.repository }} ${{ github.event.pull_request.number }}
+            npx gh-pr-render "$REPO" "$PR_NUMBER"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
+      # WARNING: action is not pinned to a SHA here
       - uses: anthropics/claude-code-action@v1
         with:
           # You can set either of these secrets. If both are set, the API key
@@ -47,4 +93,4 @@ jobs:
             ${{ steps.render.outputs.pr_context }}
 
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Read,Bash(find:*),Bash(grep:*),Bash(git log:*),Bash(git diff:*),Bash(git blame:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run list:*),Bash(gh run view:*),Bash(gh api:*)"


### PR DESCRIPTION
Adds a bunch of new triggers, including comments so that Claude can be
accessed with `@claude`. Adds checks that the comment/issue/review
author summoning Claude is a collaborator or owner of the repo.

Adds a bunch of WARNING comments discussing security implications.

Gives Claude more tools to access PR information. It includes broad API
access, but the API access is limited by the GitHub token and thus the
permissions set on the workflow.

Prevents likely-already-impossible shell injection by setting
environment variables to the repo name and PR number before calling
`gh-pr-render`.
