### PR TITLE
Reschedule `prek` job to 5am Fridays PDT

### DIFF
--- a/.github/workflows/prek-auto-update.yaml
+++ b/.github/workflows/prek-auto-update.yaml
@@ -2,7 +2,7 @@ name: prek auto-update
 
 on:
   schedule:
-    - cron: "0 9 * * 1" # Every Monday at 9:00 UTC
+    - cron: "0 12 * * 5" # Every Friday at 12:00 UTC (5am PDT / 4am PST).
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
The time is set as UTC, so it will shift by an hour during the daylight
saving time switch.
