### PR TITLE
`pinact run -u`: update action versions

### DIFF
--- a/.github/workflows/claude-pr-reviews.yaml
+++ b/.github/workflows/claude-pr-reviews.yaml
@@ -27,12 +27,12 @@ jobs:
       issues: write # Write issue comments
       actions: read # Read GitHub action results
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 2
           persist-credentials: false
 
-      - uses: danielparks/claude-pr-review@1567ea721defa4614e1e8bd40ba156f9cd81377b # v1
+      - uses: danielparks/claude-pr-review@1567ea721defa4614e1e8bd40ba156f9cd81377b # v1.0.0
         with:
           # You can set either of these secrets. If both are set, the API key
           # seems to win.

--- a/.github/workflows/claude-response.yaml
+++ b/.github/workflows/claude-response.yaml
@@ -54,12 +54,12 @@ jobs:
       issues: write # Write issue comments
       actions: read # Read GitHub action results
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
           persist-credentials: false
 
-      - uses: anthropics/claude-code-action@787c5a0ce96a9a6cfb050ea0c8f4c05f2447c251 # v1.0.133
+      - uses: anthropics/claude-code-action@64de744025ca9e24df2b88204b4f1e968f39f009 # v1.0.139
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -25,7 +25,7 @@ jobs:
       security-events: write # SARIF reporting for zizmor
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -43,15 +43,15 @@ jobs:
           toolchain: nightly
           components: rustfmt
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-      - uses: taiki-e/install-action@60ae4ce63c7aeb6e96d7f572c1ec7fafbb17ca80 # v2.79.10
+      - uses: taiki-e/install-action@56545b37b57562edd73171cb6c62cc509db4c34e # v2.81.7
         with:
           tool: cargo-msrv
 
       - run: deno install --frozen
 
-      - uses: crate-ci/typos@7b04f660f4ee4f048d18fd341887cf28dfbedfe2 # v1.46.3
+      - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
         if: ${{ !cancelled() }}
 
       - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
@@ -80,7 +80,7 @@ jobs:
       - uses: actions-rust-lang/rustfmt@4066006ec54a31931b9b1fddfd38f2fdf2d27143 # v1.1.2
         if: ${{ !cancelled() }}
 
-      - uses: EmbarkStudios/cargo-deny-action@a531616d8ce3b9177443e48a1159bc945a099823 # v2.0.19
+      - uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
         if: ${{ !cancelled() }}
         with:
           rust-version: "1.85.0"

--- a/.github/workflows/prek-auto-update.yaml
+++ b/.github/workflows/prek-auto-update.yaml
@@ -19,4 +19,4 @@ jobs:
         with:
           # zizmor: ignore[artipacked] no archive; needed for git
           persist-credentials: true
-      - uses: danielparks/github-actions/prek-auto-update@066bc679390bd9adf0780e681993bdd28cf4d8e2 # v1.1.0
+      - uses: danielparks/github-actions/prek-auto-update@2f6c98c73f0a8130d737500b59a0fddf749b484d # v1.1.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: danielparks/github-actions/create-release@e6897e1bad61baaecaf6683db8a69747ddcf40f1 # v1.0.0
+      - uses: danielparks/github-actions/create-release@2f6c98c73f0a8130d737500b59a0fddf749b484d # v1.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           working-directory: backend
@@ -64,7 +64,7 @@ jobs:
           - target: s390x-unknown-linux-gnu
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
-      - uses: danielparks/github-actions/create-release-artifacts@e6897e1bad61baaecaf6683db8a69747ddcf40f1 # v1.0.0
+      - uses: danielparks/github-actions/create-release-artifacts@2f6c98c73f0a8130d737500b59a0fddf749b484d # v1.1.1
         with:
           binary: repoyear-backend
           target: ${{ matrix.target }}


### PR DESCRIPTION
This should fix the `prek-auto-update` workflow.
