### PR TITLE
Fix caching across token refreshes, and a few tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
   model does not support it.
 - Now displays “Loading…” instead of “No contributions data” when loading data
   from GitHub before any data has arrived.
+- No longer loses cached data when the GitHub token refreshes.
 
 ## 0.8.1 (2026-03-07)
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { Footer } from "./components/Footer.tsx";
 import { Icon } from "./components/Icon.tsx";
 import { getAppVersion } from "./version.ts";
 import { useTokenManager } from "./hooks/useTokenManager.ts";
+import { clearQueryCache } from "./components/QueryCache.tsx";
 import { arrayStartsWith, sum } from "./util.ts";
 import equal from "fast-deep-equal";
 
@@ -32,7 +33,12 @@ export default function App(
   },
 ) {
   const { tokenData, clearTokenData, exchangeAccessToken, refreshAccessToken } =
-    useTokenManager();
+    useTokenManager(() => {
+      queryClient.clear();
+      clearQueryCache().catch((error: unknown) => {
+        console.error("Error clearing query cache:", error);
+      });
+    });
   const [authError, setAuthError] = useState<string | null>(initialAuthError);
   const [authCode, setAuthCode] = useState<string | null>(initialAuthCode);
   const [localContributions, setLocalContributions] = useState<
@@ -68,7 +74,6 @@ export default function App(
   const queryKey = [
     "contributions.2",
     CONTRIBUTIONS_QUERY_TEMPLATE,
-    tokenData?.accessToken,
     username,
   ];
   const query = useQuery({
@@ -110,7 +115,8 @@ export default function App(
             setAuthError("Session expired. Please log in again.");
             throw error;
           }
-          // The accessToken changed, so next tick this will reload.
+          // Reset so the in-render condition triggers a refetch with the new token.
+          startedFetch.current = false;
           return { complete: false, contributions: [] };
         } else {
           throw error;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ export default function App(
     githubClientId: string;
   },
 ) {
+  const queryClient = useQueryClient();
   const { tokenData, clearTokenData, exchangeAccessToken, refreshAccessToken } =
     useTokenManager(() => {
       queryClient.clear();
@@ -46,7 +47,6 @@ export default function App(
   >(null);
   const authCodeHandled = useRef<boolean>(false);
   const startedFetch = useRef<boolean>(false);
-  const queryClient = useQueryClient();
 
   // loading and loadingPercent are separate because when we calculate the
   // loading percentage we don’t know if the query has finished. We might
@@ -115,7 +115,7 @@ export default function App(
             setAuthError("Session expired. Please log in again.");
             throw error;
           }
-          // Reset so the in-render condition triggers a refetch with the new token.
+          // Reset to trigger a refetch with the new token.
           startedFetch.current = false;
           return { complete: false, contributions: [] };
         } else {

--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -4,9 +4,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App.tsx";
 import type { Contributions } from "./github/api.ts";
-import fixtureData from "./__fixtures__/github.json" with {
-  type: "json",
-};
+import fixtureData from "./__fixtures__/github.json" with { type: "json" };
 
 class MockHttpError extends Error {
   status = 401;

--- a/src/components/CalendarHeatMap.css
+++ b/src/components/CalendarHeatMap.css
@@ -15,18 +15,31 @@ body.compact .calendar-heat-map {
   justify-content: center;
   top: 0;
   bottom: 0;
-  left: 0;
-  right: 0;
+  left: 1rlh;
+  right: 1rlh;
   background: hsl(200deg 20% 95%);
   color: hsl(200deg 20% 40%);
   padding: 15px;
   border-radius: 6px;
 }
 
+.calendar-heat-map > .message::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -1rlh;
+  right: -1rlh;
+  background: #fff;
+  z-index: -1;
+}
+
 .calendar-heat-map > .weeks {
+  position: relative;
   display: flex;
   overflow-x: auto;
   padding: 0 1rlh;
+  z-index: -2;
 }
 
 .calendar-heat-map > .weeks > .week {

--- a/src/components/QueryCache.tsx
+++ b/src/components/QueryCache.tsx
@@ -31,12 +31,8 @@ export default function QueryCacheProvider({ children }: PropsWithChildren) {
       persistClient: async (client: PersistedClient) => {
         await set(idbKey, client);
       },
-      restoreClient: async () => {
-        return await get<PersistedClient>(idbKey);
-      },
-      removeClient: async () => {
-        await del(idbKey);
-      },
+      restoreClient: async () => await get<PersistedClient>(idbKey),
+      removeClient: async () => await del(idbKey),
     } as Persister,
     // Keep data in IndexedDB indefinitely
     maxAge: Infinity,

--- a/src/components/QueryCache.tsx
+++ b/src/components/QueryCache.tsx
@@ -7,12 +7,13 @@ import type {
   Persister,
 } from "@tanstack/react-query-persist-client";
 
+const IDB_KEY: IDBValidKey = `${location.pathname} contributions`;
+
 export async function clearQueryCache(): Promise<void> {
-  await del(`${location.pathname} contributions`);
+  await del(IDB_KEY);
 }
 
 export default function QueryCacheProvider({ children }: PropsWithChildren) {
-  const idbKey: IDBValidKey = `${location.pathname} contributions`;
   const client = new QueryClient({
     defaultOptions: {
       queries: {
@@ -33,10 +34,10 @@ export default function QueryCacheProvider({ children }: PropsWithChildren) {
   const options = {
     persister: {
       persistClient: async (client: PersistedClient) => {
-        await set(idbKey, client);
+        await set(IDB_KEY, client);
       },
-      restoreClient: async () => await get<PersistedClient>(idbKey),
-      removeClient: async () => await del(idbKey),
+      restoreClient: async () => await get<PersistedClient>(IDB_KEY),
+      removeClient: async () => await del(IDB_KEY),
     } as Persister,
     // Keep data in IndexedDB indefinitely
     maxAge: Infinity,

--- a/src/components/QueryCache.tsx
+++ b/src/components/QueryCache.tsx
@@ -7,6 +7,10 @@ import type {
   Persister,
 } from "@tanstack/react-query-persist-client";
 
+export async function clearQueryCache(): Promise<void> {
+  await del(`${location.pathname} contributions`);
+}
+
 export default function QueryCacheProvider({ children }: PropsWithChildren) {
   const idbKey: IDBValidKey = `${location.pathname} contributions`;
   const client = new QueryClient({

--- a/src/hooks/useTokenManager.ts
+++ b/src/hooks/useTokenManager.ts
@@ -11,7 +11,7 @@ export interface GitHubTokenData {
   refreshTokenExpiresAt?: number;
 }
 
-export function useTokenManager() {
+export function useTokenManager(onClear?: () => void) {
   const [tokenData, setTokenData] = useState<GitHubTokenData | null>(
     getStoredTokenData,
   );
@@ -19,6 +19,7 @@ export function useTokenManager() {
   function clearTokenData() {
     localStorage.removeItem(STORAGE_KEY);
     setTokenData(null);
+    onClear?.();
   }
 
   async function exchangeAccessToken(code: string) {


### PR DESCRIPTION
- **Add margins to calendar loading message.**
  

- **Formatting: make `QueryCache` options more compact.**
  

- **Fix calendar blanking on revisit by removing token from cache key**
  The access token was part of the query key, so when GitHub returned 401
  and the token was refreshed mid-fetch, the query key changed and the new
  key had no cached data, blanking the calendar until fresh data arrived.
  
  Fix: remove the token from the key (token refreshes for the same user
  should reuse the same cache), and clear both in-memory and IndexedDB
  caches on logout so different users don't see each other's data.
  
  After a successful token refresh, reset startedFetch so the in-render
  condition triggers a refetch with the new token, replacing the old
  implicit trigger of a query key change.
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **Formatting and comment tweaks.**
  