### PR TITLE
Fix: Make calendar interactable again

### DIFF
--- a/src/components/CalendarHeatMap.css
+++ b/src/components/CalendarHeatMap.css
@@ -2,6 +2,7 @@
   display: block;
   position: relative;
   margin: 1rlh -2rlh;
+  isolation: isolate;
 }
 
 body.compact .calendar-heat-map {


### PR DESCRIPTION
The inner container was given a negative `z-index` to keep it below
`div.message` and its background, but that put it behind its container
(I think). The solution was to give its container (the outer container)
a `z-index` to establish a stacking context that the inner context could
not be placed behind.
