### PR TITLE
Fix horizontal scrolling in narrow windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Now displays “Loading…” instead of “No contributions data” when loading data
   from GitHub before any data has arrived.
 - No longer loses cached data when the GitHub token refreshes.
+- Extend calendar map to the edges of the screen in narrow windows or on mobile.
 
 ## 0.8.1 (2026-03-07)
 

--- a/src/components/CalendarHeatMap.css
+++ b/src/components/CalendarHeatMap.css
@@ -127,3 +127,23 @@ body.compact .calendar-heat-map {
 .calendar-heat-map > .weeks > .week > div > ol > li {
   height: 100%;
 }
+
+@media (max-width: 550px) {
+  .calendar-heat-map {
+    margin: 1rlh -1rlh;
+  }
+
+  .calendar-heat-map > .weeks {
+    padding: 0;
+  }
+
+  .calendar-heat-map > .message {
+    left: 0;
+    right: 0;
+  }
+
+  .calendar-heat-map > .message::before {
+    left: 0;
+    right: 0;
+  }
+}


### PR DESCRIPTION
Previously, the calendar extended past the edges of the viewport in
narrow windows, which triggered horizontal scrolling on the body. This
removes the body scrolling by only extending the calendar to the edges
of the viewport.

This also adds the new layout to the CHANGELOG (it was added in a
previous commit).
