### PR TITLE
Test: increase timeout

### DIFF
--- a/src/App.vitest.tsx
+++ b/src/App.vitest.tsx
@@ -136,7 +136,7 @@ describe("App smoke test", () => {
 
       expect(document.querySelector(".calendar-heat-map"))
         .toBeInTheDocument();
-    }, { timeout: 500 });
+    }, { timeout: 1000 });
 
     await waitFor(() => {
       expect(screen.queryByText(/Loading/i, { selector: "button" })).not


### PR DESCRIPTION
One test was running close to the timeout time when running in a Docker
container. This doubles the timeout.
