### PR TITLE
Clean up `Calendar.pagination.test.ts`

### DIFF
--- a/src/model/Calendar.pagination.test.ts
+++ b/src/model/Calendar.pagination.test.ts
@@ -8,7 +8,7 @@
  * `calendar: undefined`.
  */
 import { assertEquals } from "@std/assert";
-import { ALL_ON, Calendar } from "./index.ts";
+import { ALL_ON, Calendar, Day } from "./index.ts";
 import type { Contributions } from "../github/api.ts";
 
 const REPO_URL = "https://github.com/test/repo";
@@ -87,6 +87,24 @@ function summaryChunk(
     },
     ...partial,
   });
+}
+
+type NumberMethodNames<T> = {
+  [K in keyof T]: T[K] extends () => number ? K : never;
+}[keyof T];
+
+/** Make an assertion function for a count method on `Day`. */
+function _makeDayCountAssert(name: string, method: NumberMethodNames<Day>) {
+  return (day: Day, expected: number, message: string = "") => {
+    const func = day[method] as unknown as () => number;
+    assertEquals(
+      func.apply(day, []),
+      expected,
+      `${day.dateString()} ${name} should equal ${expected}${
+        message && ": " + message
+      }`,
+    );
+  };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/model/Calendar.pagination.test.ts
+++ b/src/model/Calendar.pagination.test.ts
@@ -7,8 +7,8 @@
  * summary calendar for the first page; subsequent pages have
  * `calendar: undefined`.
  */
-import { assertEquals } from "@std/assert";
-import { ALL_ON, Calendar, Day } from "./index.ts";
+import { assert, assertEquals } from "@std/assert";
+import { Calendar, Day } from "./index.ts";
 import type { Contributions } from "../github/api.ts";
 
 const REPO_URL = "https://github.com/test/repo";
@@ -94,7 +94,7 @@ type NumberMethodNames<T> = {
 }[keyof T];
 
 /** Make an assertion function for a count method on `Day`. */
-function _makeDayCountAssert(name: string, method: NumberMethodNames<Day>) {
+function makeDayCountAssert(name: string, method: NumberMethodNames<Day>) {
   return (day: Day, expected: number, message: string = "") => {
     const func = day[method] as unknown as () => number;
     assertEquals(
@@ -106,6 +106,42 @@ function _makeDayCountAssert(name: string, method: NumberMethodNames<Day>) {
     );
   };
 }
+
+/** Assert `day`’s contributionCount equals `expected`. */
+function assertContributionCount(
+  day: Day,
+  expected: number,
+  message: string = "",
+) {
+  assertEquals(
+    day.contributionCount,
+    expected,
+    `${day.dateString()} contributionCount should equal ${expected}${
+      message && ": " + message
+    }`,
+  );
+}
+
+/** Assert `day`’s calculated contributions equal `expected`. */
+const assertContributions = makeDayCountAssert(
+  "known contributions",
+  "knownContributionCount",
+);
+
+/** Assert `day`’s commits equal `expected`. */
+const assertCommits = makeDayCountAssert("commits", "commitCount");
+
+/** Assert `day`’s issues equal `expected`. */
+const assertIssues = makeDayCountAssert("issues", "issueCount");
+
+/** Assert `day`’s PRs equal `expected`. */
+const assertPrs = makeDayCountAssert("PRs", "prCount");
+
+/** Assert `day`’s PR reviews equal `expected`. */
+const assertReviews = makeDayCountAssert("PR reviews", "reviewCount");
+
+/** Assert `day`’s unknowns equal `expected`. */
+const assertUnknowns = makeDayCountAssert("unknowns", "unknownCount");
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Commit pagination
@@ -132,34 +168,18 @@ Deno.test("Calendar should link commits from paginated second chunk", () => {
 
   // June 1 is covered by the first chunk — should always be linked.
   const june1 = days.get("2024-06-01")!;
-  assertEquals(
-    june1?.contributionCount,
-    1,
-    "June 1 should have 1 contribution",
-  );
-  assertEquals(
-    june1?.unknownCount(),
-    0,
-    "June 1 should have no unknown contributions",
-  );
+  assertContributionCount(june1, 1, "first chunk");
+  assertContributions(june1, 1, "first chunk");
+  assertCommits(june1, 1, "first chunk");
+  assertUnknowns(june1, 0, "first chunk");
 
-  // June 15 is covered by the second (paginated) chunk — currently broken.
+  // June 15 is covered by the second (paginated) chunk.
   const june15 = days.get("2024-06-15")!;
-  assertEquals(
-    june15?.contributionCount,
-    1,
-    "June 15 should have 1 contribution",
-  );
-  assertEquals(
-    june15?.unknownCount(),
-    0,
-    "June 15 commit should not be unknown (it was on paginated page 2)",
-  );
-  assertEquals(
-    june15?.repositories.has(REPO_URL),
-    true,
-    "June 15 should be linked to the repo",
-  );
+  assertContributionCount(june15, 1, "second chunk");
+  assertContributions(june15, 1, "second chunk");
+  assertCommits(june15, 1, "second chunk");
+  assertUnknowns(june15, 0, "second chunk");
+  assert(june15.repositories.has(REPO_URL), "6/15 should have repo");
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -182,12 +202,10 @@ Deno.test("Calendar should link issues from paginated second chunk", () => {
   }).daysByDate();
 
   const june15 = days.get("2024-06-15")!;
-  assertEquals(june15?.contributionCount, 1);
-  assertEquals(
-    june15?.unknownCount(),
-    0,
-    "June 15 issue should not be unknown (it was on paginated page 2)",
-  );
+  assertContributionCount(june15, 1, "second chunk");
+  assertContributions(june15, 1, "second chunk");
+  assertIssues(june15, 1, "second chunk");
+  assertUnknowns(june15, 0, "second chunk");
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -210,12 +228,10 @@ Deno.test("Calendar should link PRs from paginated second chunk", () => {
   }).daysByDate();
 
   const june15 = days.get("2024-06-15")!;
-  assertEquals(june15?.contributionCount, 1);
-  assertEquals(
-    june15?.unknownCount(),
-    0,
-    "June 15 PR should not be unknown (it was on paginated page 2)",
-  );
+  assertContributionCount(june15, 1, "second chunk");
+  assertContributions(june15, 1, "second chunk");
+  assertPrs(june15, 1, "second chunk");
+  assertUnknowns(june15, 0, "second chunk");
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -238,12 +254,10 @@ Deno.test("Calendar should link PR reviews from paginated second chunk", () => {
   }).daysByDate();
 
   const june15 = days.get("2024-06-15")!;
-  assertEquals(june15?.contributionCount, 1);
-  assertEquals(
-    june15?.unknownCount(),
-    0,
-    "June 15 review should not be unknown (it was on paginated page 2)",
-  );
+  assertContributionCount(june15, 1, "second chunk");
+  assertContributions(june15, 1, "second chunk");
+  assertReviews(june15, 1, "second chunk");
+  assertUnknowns(june15, 0, "second chunk");
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -280,22 +294,12 @@ Deno.test("Calendar should link paginated events across multiple years", () => {
   for (
     const dateStr of ["2024-06-01", "2024-06-15", "2023-06-01", "2023-06-15"]
   ) {
-    const day = days.get(dateStr);
-    assertEquals(
-      day?.contributionCount,
-      1,
-      `${dateStr} should have 1 contribution`,
-    );
-    assertEquals(
-      day?.unknownCount(),
-      0,
-      `${dateStr} should have no unknown contributions`,
-    );
-    assertEquals(
-      day?.repositories.has(REPO_URL),
-      true,
-      `${dateStr} should be linked to the repo`,
-    );
+    const day = days.get(dateStr)!;
+    assertContributionCount(day, 1);
+    assertContributions(day, 1);
+    assertCommits(day, 1);
+    assertUnknowns(day, 0);
+    assert(day.repositories.has(REPO_URL), `${dateStr} should have repo`);
   }
 });
 
@@ -331,14 +335,8 @@ Deno.test("Calendar should not double-count via paginated chunks at year boundar
   }).daysByDate();
 
   const boundaryDay = days.get("2024-06-01")!;
-  assertEquals(
-    boundaryDay?.contributionCount,
-    2,
-    "Boundary day has 2 contributions",
-  );
-  assertEquals(
-    boundaryDay?.filteredCount(ALL_ON),
-    2,
-    "Boundary day should not be double-counted from paginated older-year chunk",
-  );
+  assertContributionCount(boundaryDay, 2);
+  assertContributions(boundaryDay, 2);
+  assertCommits(boundaryDay, 2);
+  assertUnknowns(boundaryDay, 0);
 });

--- a/src/model/Calendar.pagination.test.ts
+++ b/src/model/Calendar.pagination.test.ts
@@ -3,8 +3,9 @@
  * summary calendar) are correctly attributed to repositories.
  *
  * When GitHub has more than 100 contributions of a given type in a year, it
- * paginates them across multiple API responses. Only the first response
- * includes a summary calendar; subsequent pages have `calendar: undefined`.
+ * paginates them across multiple API responses. Our query only requests the
+ * summary calendar for the first page; subsequent pages have
+ * `calendar: undefined`.
  */
 import { assertEquals } from "@std/assert";
 import { ALL_ON, Calendar } from "./index.ts";
@@ -73,9 +74,7 @@ function summaryChunk(
   dates: Array<[string, number]>,
   partial: object,
 ): Contributions {
-  return {
-    login: "testuser",
-    name: "Test User",
+  return paginatedChunk({
     calendar: {
       totalContributions: dates.reduce((s, [, n]) => s + n, 0),
       weeks: dates.map(([date, count]) => ({
@@ -86,13 +85,8 @@ function summaryChunk(
         }],
       })),
     },
-    commits: [],
-    issues: [],
-    prs: [],
-    repositories: [],
-    reviews: [],
     ...partial,
-  } as unknown as Contributions;
+  });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/model/Calendar.pagination.test.ts
+++ b/src/model/Calendar.pagination.test.ts
@@ -106,15 +106,11 @@ Deno.test("Calendar should link commits from paginated second chunk", () => {
     paginatedChunk({ commits: commitsEntry([["2024-06-15", 1]]) }),
   ];
 
-  const calendar = Calendar.fromContributions({
+  const days = Calendar.fromContributions({
     gitHub,
     endDate: new Date(2024, 11, 31),
     years: 1,
-  });
-
-  const days = new Map(
-    calendar.days.map((d) => [d.date.toISOString().slice(0, 10), d]),
-  );
+  }).daysByDate();
 
   // June 1 is covered by the first chunk — should always be linked.
   const june1 = days.get("2024-06-01")!;
@@ -161,15 +157,11 @@ Deno.test("Calendar should link issues from paginated second chunk", () => {
     paginatedChunk({ issues: issueNodes([["2024-06-15", 2]]) }),
   ];
 
-  const calendar = Calendar.fromContributions({
+  const days = Calendar.fromContributions({
     gitHub,
     endDate: new Date(2024, 11, 31),
     years: 1,
-  });
-
-  const days = new Map(
-    calendar.days.map((d) => [d.date.toISOString().slice(0, 10), d]),
-  );
+  }).daysByDate();
 
   const june15 = days.get("2024-06-15")!;
   assertEquals(june15?.contributionCount, 1);
@@ -193,15 +185,11 @@ Deno.test("Calendar should link PRs from paginated second chunk", () => {
     paginatedChunk({ prs: prNodes([["2024-06-15", 2]]) }),
   ];
 
-  const calendar = Calendar.fromContributions({
+  const days = Calendar.fromContributions({
     gitHub,
     endDate: new Date(2024, 11, 31),
     years: 1,
-  });
-
-  const days = new Map(
-    calendar.days.map((d) => [d.date.toISOString().slice(0, 10), d]),
-  );
+  }).daysByDate();
 
   const june15 = days.get("2024-06-15")!;
   assertEquals(june15?.contributionCount, 1);
@@ -225,15 +213,11 @@ Deno.test("Calendar should link PR reviews from paginated second chunk", () => {
     paginatedChunk({ reviews: reviewNodes([["2024-06-15", 2]]) }),
   ];
 
-  const calendar = Calendar.fromContributions({
+  const days = Calendar.fromContributions({
     gitHub,
     endDate: new Date(2024, 11, 31),
     years: 1,
-  });
-
-  const days = new Map(
-    calendar.days.map((d) => [d.date.toISOString().slice(0, 10), d]),
-  );
+  }).daysByDate();
 
   const june15 = days.get("2024-06-15")!;
   assertEquals(june15?.contributionCount, 1);
@@ -269,15 +253,11 @@ Deno.test("Calendar should link paginated events across multiple years", () => {
     paginatedChunk({ commits: commitsEntry([["2023-06-15", 1]]) }),
   ];
 
-  const calendar = Calendar.fromContributions({
+  const days = Calendar.fromContributions({
     gitHub,
     endDate: new Date(2024, 11, 31),
     years: 2,
-  });
-
-  const days = new Map(
-    calendar.days.map((d) => [d.date.toISOString().slice(0, 10), d]),
-  );
+  }).daysByDate();
 
   for (
     const dateStr of ["2024-06-01", "2024-06-15", "2023-06-01", "2023-06-15"]
@@ -326,15 +306,11 @@ Deno.test("Calendar should not double-count via paginated chunks at year boundar
     paginatedChunk({ commits: commitsEntry([["2024-06-01", 2]]) }),
   ];
 
-  const calendar = Calendar.fromContributions({
+  const days = Calendar.fromContributions({
     gitHub,
     endDate: new Date(2024, 11, 31),
     years: 2,
-  });
-
-  const days = new Map(
-    calendar.days.map((d) => [d.date.toISOString().slice(0, 10), d]),
-  );
+  }).daysByDate();
 
   const boundaryDay = days.get("2024-06-01")!;
   assertEquals(

--- a/src/model/Calendar.ts
+++ b/src/model/Calendar.ts
@@ -562,6 +562,13 @@ export class Calendar {
       yield this.days.slice(i, i + 7);
     }
   }
+
+  /**
+   * Returns a map of Days indexed by date string (YYYY-MM-DD local time).
+   */
+  daysByDate(): Map<string, Day> {
+    return new Map(this.days.map((day) => [day.dateString(), day]));
+  }
 }
 
 /**

--- a/src/model/Day.test.ts
+++ b/src/model/Day.test.ts
@@ -160,3 +160,10 @@ Deno.test("Day should check if day has specific repo", () => {
   assert(day.hasRepo("https://github.com/test/repo"));
   assert(!day.hasRepo("https://github.com/other/repo"));
 });
+
+Deno.test("Day.dateString() is in the local timezone", () => {
+  // This only works if the timezone isn’t UTC (it will always pass in UTC).
+  for (let h = 0; h < 24; h++) {
+    assertEquals(new Day(new Date(2025, 0, 1, h)).dateString(), "2025-01-01");
+  }
+});

--- a/src/model/Day.test.ts
+++ b/src/model/Day.test.ts
@@ -161,9 +161,12 @@ Deno.test("Day should check if day has specific repo", () => {
   assert(!day.hasRepo("https://github.com/other/repo"));
 });
 
-Deno.test("Day.dateString() is in the local timezone", () => {
-  // This only works if the timezone isn’t UTC (it will always pass in UTC).
-  for (let h = 0; h < 24; h++) {
-    assertEquals(new Day(new Date(2025, 0, 1, h)).dateString(), "2025-01-01");
-  }
+Deno.test({
+  name: "Day.dateString() is in the local timezone",
+  ignore: Intl.DateTimeFormat().resolvedOptions().timeZone === "UTC",
+  fn() {
+    for (let h = 0; h < 24; h++) {
+      assertEquals(new Day(new Date(2025, 0, 1, h)).dateString(), "2025-01-01");
+    }
+  },
 });

--- a/src/model/Day.ts
+++ b/src/model/Day.ts
@@ -85,6 +85,13 @@ export class Day {
   }
 
   /**
+   * Get number of commits made on this repository on this day.
+   */
+  commitCount(filter: Filter = ALL_ON): number {
+    return sum(this.filteredRepos(filter), (repoDay) => repoDay.commitCount);
+  }
+
+  /**
    * Get number of issues opened on this repository on this day.
    */
   issueCount(filter: Filter = ALL_ON): number {

--- a/src/model/Day.ts
+++ b/src/model/Day.ts
@@ -2,6 +2,9 @@ import { Repository } from "./Repository.ts";
 import { ALL_ON, Filter } from "./Filter.ts";
 import { sum } from "../util.ts";
 
+// The Swedish locale uses ISO 8601.
+const ISO8601 = new Intl.DateTimeFormat("sv");
+
 /**
  * Represents a single day in the contribution calendar.
  *
@@ -27,6 +30,13 @@ export class Day {
    */
   epochDay() {
     return toEpochDays(this.date);
+  }
+
+  /**
+   * Get the date as YYYY-MM-DD.
+   */
+  dateString() {
+    return ISO8601.format(this.date);
   }
 
   /**


### PR DESCRIPTION
- **`Calendar.pagination.test.ts`: clarify docs and simplify mocking code.**
  

- **`Calendar`: make it easy to get `Day`s by date string**
  This is useful for testing.
  

- **`Calendar.pagination.test.ts`: make assertions for `Day` count methods**
  Claude wrote the type handling code for accessing the method by name.
  
  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
  

- **`Calendar.pagination.test.ts`: make tests easier to read.**
  