### PR TITLE
Clean up extra-week GitHub fixture test

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -88,6 +88,7 @@ export default function App(
       setLoading(true);
       setLoadingPercent(0);
       setAuthError(null); // The ability to query implies we’re authenticated.
+      const endDate = new Date();
 
       const gh = new github.GitHub(tokenData.accessToken);
       gh.installRateLimitReport();
@@ -100,6 +101,7 @@ export default function App(
           queryClient.setQueryData(queryKey, {
             complete: false,
             contributions: [...contributions],
+            endDate,
           });
         }
       } catch (error: unknown) {
@@ -117,14 +119,14 @@ export default function App(
           }
           // Reset to trigger a refetch with the new token.
           startedFetch.current = false;
-          return { complete: false, contributions: [] };
+          return { complete: false, contributions: [], endDate };
         } else {
           throw error;
         }
       }
 
       setLoading(false);
-      return { complete: true, contributions };
+      return { complete: true, contributions, endDate };
     },
   });
 
@@ -143,7 +145,7 @@ export default function App(
     }
   }, [query?.data?.complete]);
 
-  const contributions = query.data?.contributions;
+  const { contributions, endDate } = query.data ?? { endDate: new Date() };
 
   useEffect(() => {
     if (localContributions === null) {
@@ -187,7 +189,7 @@ export default function App(
       calendar.appendGitHubUpdates(gitHub.slice(prev.gitHub.length));
     } else {
       // Something changed that requires full regeneration.
-      calendar = Calendar.fromContributions({ gitHub, local, years });
+      calendar = Calendar.fromContributions({ gitHub, local, years, endDate });
     }
 
     // Calculate progress bar.

--- a/src/hooks/useStaticCalendar.ts
+++ b/src/hooks/useStaticCalendar.ts
@@ -68,6 +68,7 @@ export function useStaticCalendar(): UseStaticCalendarResult {
       Calendar.fromContributions({
         gitHub: contributions || [],
         local: localContributions ? [localContributions] : [],
+        endDate: fetchedAt ? new Date(fetchedAt) : new Date(),
       }),
     [contributions, localContributions],
   );

--- a/src/model/Calendar.fixture.test.ts
+++ b/src/model/Calendar.fixture.test.ts
@@ -32,23 +32,35 @@ function getLastDate(contributions: Contributions[]): Date {
 // Extra-week handling
 // ----------------------------------------------------------------------------
 
-// The extra-week fixture has commits for 2025-03-30 through 2025-04-05 in chunk
-// 1, which has no summary calendar. Those dates are before the summary start of
-// 2025-04-06 and should be silently dropped.
+// The extra-week fixture has commits for 2025-03-30 through 2025-04-05, but no
+// summary calendar data for those days. Those dates should be silently dropped.
 Deno.test("Calendar should not create days from specific events outside summary range", () => {
+  const summaryStart = getFirstDate(extraWeekContributions);
+
+  let found = false;
+  for (const contributions of extraWeekContributions) {
+    for (const repo of contributions.commits) {
+      for (const commit of repo.contributions!.nodes ?? []) {
+        if (commit && new Date(commit.occurredAt) < summaryStart) {
+          found = true;
+          break;
+        }
+      }
+    }
+  }
+  assert(found, `No commits before first summary day (${summaryStart})`);
+
   const calendar = Calendar.fromContributions({
     gitHub: extraWeekContributions,
+    endDate: getLastDate(extraWeekContributions),
   });
-
-  // Summary calendar starts 2025-04-06. Any day before that with
-  // knownContributionCount() > 0 came from the spurious extra-week events.
-  const summaryStart = new Date(2025, 3, 6); // April 6, 2025
   for (const day of calendar.days) {
     if (day.date < summaryStart) {
       assertEquals(
         day.knownContributionCount(),
         0,
-        `Day ${day.dateString()} should have no specific contributions`,
+        `Day ${day.dateString()} (before ${summaryStart}) should have no ` +
+          "specific contributions",
       );
     }
   }

--- a/src/model/Calendar.ts
+++ b/src/model/Calendar.ts
@@ -93,10 +93,10 @@ export class Calendar {
    * Creates a Calendar from GitHub and/or local contributions data.
    */
   static fromContributions(
-    { gitHub = [], local = [], endDate = new Date(), years = 1 }: {
+    { gitHub = [], local = [], endDate, years = 1 }: {
       gitHub?: github.Contributions[];
       local?: Record<string, number[]>[];
-      endDate?: Date;
+      endDate: Date;
       years?: number;
     },
   ): Calendar {


### PR DESCRIPTION
The test no longer relies on knowledge about specific dates in the data,
checks if the data exhibits the problematic behavior, and then verifies
we handle it correctly.
