### PR TITLE
Security: update anyhow to avoid potential unsoundness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert2"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-anyhow = "1.0.95"
+anyhow = "1.0.103"
 clap = { version = "4.5.27", features = ["derive", "env"] }
 dropshot = "0.16.3"
 git2 = { version = "0.21.0", default-features = false }


### PR DESCRIPTION
[RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190):

> Affected versions of this crate violate borrow rules, resulting in
> undefined behavior, when the user adds context to an error via
> `Error::context` and then later calls `Error::downcast_mut` on the
> returned `Error`.

RepoYear doesn’t use `downcast_mut` so it isn’t affected. Upgrading
the dependency anyway.
