### PR TITLE
Simplify `Calendar.day` (now read-only)

### DIFF
--- a/src/model/Calendar.test.ts
+++ b/src/model/Calendar.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStrictEquals } from "@std/assert";
+import { assertEquals, assertExists, assertStrictEquals } from "@std/assert";
 import { Calendar, Day, Repository } from "./index.ts";
 import * as gql from "../github/gql.ts";
 
@@ -33,32 +33,31 @@ Deno.test("Calendar should calculate max contributions", () => {
 });
 
 Deno.test("Calendar.updateRepoCounts() should clear stale unknown repo", () => {
+  const date = new Date(2025, 0, 1);
   // Simulates progressive loading: summary arrives first (all contributions
   // appear unknown), then specific events arrive that account for everything.
-  const calendar = new Calendar("testuser");
-  const date = new Date(2025, 0, 1);
-  calendar.day(date).contributionCount = 5;
+  const calendar = new Calendar("testuser", [new Day(date, 5)]);
 
   // First call: summary only, no specific repos yet.
   calendar.updateRepoCounts();
 
   // Add specific events that account for all contributions.
-  calendar.repoDay(date, "repo1").setCommits(5);
+  calendar.repoDay(date, "repo1")!.setCommits(5);
 
   // Second call: should clear the stale "unknown" RepositoryDay.
   calendar.updateRepoCounts();
 
   const day = calendar.day(date);
-  assertEquals(day.unknownCount(), 0);
-  assertEquals(day.repositories.has("unknown"), false);
+  assertEquals(day?.unknownCount(), 0);
+  assertEquals(day?.repositories.has("unknown"), false);
 });
 
 Deno.test("Calendar should sort repos by contribution count", () => {
-  const calendar = new Calendar("testuser");
   const date = new Date(2025, 0, 1);
-  calendar.repoDay(date, "repo1").setCommits(5);
-  calendar.repoDay(date, "repo2").setCommits(10);
-  calendar.repoDay(date, "repo3").setCommits(3);
+  const calendar = new Calendar("testuser", [new Day(date)]);
+  calendar.repoDay(date, "repo1")!.setCommits(5);
+  calendar.repoDay(date, "repo2")!.setCommits(10);
+  calendar.repoDay(date, "repo3")!.setCommits(3);
   calendar.updateRepoCounts();
 
   const sorted = calendar.mostUsedRepos().map((repo) =>
@@ -72,20 +71,20 @@ Deno.test("Calendar should sort repos by contribution count", () => {
 });
 
 Deno.test("Calendar should assign distinct hues to repos by usage", () => {
-  const calendar = new Calendar("testuser");
   const date = new Date(2025, 0, 1);
+  const calendar = new Calendar("testuser", [new Day(date)]);
 
   const repo1 = new Repository("https://github.com/test/repo1");
   calendar.repositories.set(repo1.url, repo1);
-  calendar.repoDay(date, repo1.url).setCommits(10);
+  calendar.repoDay(date, repo1.url)!.setCommits(10);
 
   const repo2 = new Repository("https://github.com/test/repo2");
   calendar.repositories.set(repo2.url, repo2);
-  calendar.repoDay(date, repo2.url).setCommits(5);
+  calendar.repoDay(date, repo2.url)!.setCommits(5);
 
   const repo3 = new Repository("https://github.com/test/repo3");
   calendar.repositories.set(repo3.url, repo3);
-  calendar.repoDay(date, repo3.url).setCommits(3);
+  calendar.repoDay(date, repo3.url)!.setCommits(3);
 
   calendar.updateRepoCounts();
   calendar.updateRepoColors();
@@ -213,22 +212,8 @@ Deno.test("Calendar.weeks() should returns 7 day weeks", () => {
   ]);
 });
 
-Deno.test("Calendar.weeks() should return 7 day weeks after prepending", () => {
-  const days = [
-    new Day(new Date(2025, 0, 1), 5),
-    new Day(new Date(2025, 0, 2), 3),
-    new Day(new Date(2025, 0, 3), 2),
-  ];
-  assertEquals(days[0].date.getDay(), 3);
-
-  const calendar = new Calendar("testuser", days);
-  const day = calendar.day(new Date(2024, 11, 28));
-  day.contributionCount = 7;
-
-  assertWeeksContributions([...calendar.weeks()], new Date(2024, 11, 22), [
-    [null, null, null, null, null, null, 7],
-    [null, null, null, 5, 3, 2, null],
-  ]);
+Deno.test("Calendar.weeks() returns [] when calendar is empty", () => {
+  assertEquals([...new Calendar("testuser").weeks()], []);
 });
 
 Deno.test("Calendar.day() should return existing day when in range", () => {
@@ -244,25 +229,25 @@ Deno.test("Calendar.day() should return existing day when in range", () => {
   assertEquals(day.contributionCount, 3);
 });
 
-Deno.test("Calendar.day() should create day when calendar is empty", () => {
+Deno.test("Calendar.day() should return undefined when out of range", () => {
+  const calendar = new Calendar("testuser", [
+    new Day(new Date(2025, 0, 1), 5),
+  ]);
+  assertStrictEquals(calendar.day(new Date(2025, 1, 1)), undefined);
+});
+
+Deno.test("Calendar.day() returns undefined when calendar is empty", () => {
   const calendar = new Calendar("testuser");
-  const wednesday = new Date(2025, 0, 1);
-  assertEquals(wednesday.getDay(), 3);
-
-  const day = calendar.day(wednesday);
-  assertEquals(day.date, wednesday);
-  day.contributionCount = 9;
-
-  const dayAgain = calendar.day(wednesday);
-  assertStrictEquals(day, dayAgain);
-  assertEquals(dayAgain.contributionCount, 9);
+  assertStrictEquals(calendar.day(new Date(2025, 0, 1)), undefined);
 });
 
 Deno.test("Calendar.day() should handle earlier day in the initial week", () => {
   const calendar = new Calendar("testuser", [
     new Day(new Date(2025, 0, 1), 10),
   ]);
-  calendar.day(new Date(2024, 11, 30)).contributionCount = 3;
+  const day = calendar.day(new Date(2024, 11, 30));
+  assertExists(day);
+  day!.contributionCount = 3;
 
   assertWeeksContributions([...calendar.weeks()], new Date(2024, 11, 29), [
     [null, 3, null, 10, null, null, null],
@@ -273,108 +258,20 @@ Deno.test("Calendar.day() should handle later day in the initial week", () => {
   const calendar = new Calendar("testuser", [
     new Day(new Date(2025, 0, 1), 10),
   ]);
-  calendar.day(new Date(2025, 0, 3)).contributionCount = 3;
+  const day = calendar.day(new Date(2025, 0, 3));
+  assertExists(day);
+  day!.contributionCount = 3;
 
   assertWeeksContributions([...calendar.weeks()], new Date(2024, 11, 29), [
     [null, null, null, 10, null, 3, null],
   ]);
 });
 
-Deno.test("Calendar.day() should prepend days before initial week", () => {
-  const calendar = new Calendar("testuser", [
-    new Day(new Date(2025, 0, 1), 10),
-  ]);
-  calendar.day(new Date(2024, 11, 24)).contributionCount = 3;
-
-  assertWeeksContributions([...calendar.weeks()], new Date(2024, 11, 22), [
-    [null, null, 3, null, null, null, null],
-    [null, null, null, 10, null, null, null],
-  ]);
-});
-
-Deno.test("Calendar.day() should append days after initial week", () => {
-  const calendar = new Calendar("testuser", [
-    new Day(new Date(2025, 0, 1), 10),
-  ]);
-  calendar.day(new Date(2025, 0, 10)).contributionCount = 3;
-
-  assertWeeksContributions([...calendar.weeks()], new Date(2024, 11, 29), [
-    [null, null, null, 10, null, null, null],
-    [null, null, null, null, null, 3, null],
-  ]);
-});
-
-Deno.test("Calendar.normalizeDays() can prepend days", () => {
-  const calendar = new Calendar("testuser", [
-    new Day(new Date(2025, 0, 1), 10),
-  ]);
-  calendar.normalizeDays([new Day(new Date(2024, 11, 24), 3)]);
-
-  assertWeeksContributions([...calendar.weeks()], new Date(2024, 11, 22), [
-    [null, null, 3, null, null, null, null],
-    [null, null, null, 10, null, null, null],
-  ]);
-});
-
-Deno.test("Calendar.normalizeDays() can append days", () => {
-  const calendar = new Calendar("testuser", [
-    new Day(new Date(2025, 0, 1), 10),
-  ]);
-  calendar.normalizeDays([new Day(new Date(2025, 0, 10), 3)]);
-
-  assertWeeksContributions([...calendar.weeks()], new Date(2024, 11, 29), [
-    [null, null, null, 10, null, null, null],
-    [null, null, null, null, null, 3, null],
-  ]);
-});
-
-Deno.test("Calendar.normalizeDays() can prepend and append days", () => {
-  const calendar = new Calendar("testuser", [
-    new Day(new Date(2025, 0, 1), 10),
-  ]);
-  calendar.normalizeDays([
-    new Day(new Date(2024, 11, 24), 1),
-    new Day(new Date(2025, 0, 10), 3),
-  ]);
-
-  assertWeeksContributions([...calendar.weeks()], new Date(2024, 11, 22), [
-    [null, null, 1, null, null, null, null],
-    [null, null, null, 10, null, null, null],
-    [null, null, null, null, null, 3, null],
-  ]);
-});
-
-Deno.test("Calendar.normalizeDays() updates days", () => {
-  const calendar = new Calendar("testuser", [
-    new Day(new Date(2025, 0, 1), 10),
-    new Day(new Date(2025, 0, 2), 11),
-    new Day(new Date(2025, 0, 3), 12),
-  ]);
-  calendar.repoDay(new Date(2025, 0, 1), "test-repo").commitCount = 1;
-  calendar.normalizeDays([
-    new Day(new Date(2024, 11, 31), 1),
-    new Day(new Date(2025, 0, 1), 2),
-  ]);
-
-  const weeks = [...calendar.weeks()];
-  assertWeeksContributions(weeks, new Date(2024, 11, 29), [
-    [null, null, 1, 2, 11, 12, null],
-  ]);
-
-  assertEquals(
-    weeks[0][3].repositories.get("test-repo")?.commitCount,
-    1,
-    "Must not update details",
-  );
-});
-
-Deno.test("Calendar.normalizeDays() can accept out-of-order days", () => {
+Deno.test("new Calendar() can accept out-of-order days", () => {
   const calendar = new Calendar("testuser", [
     new Day(new Date(2025, 0, 3), 12),
     new Day(new Date(2025, 0, 1), 10),
     new Day(new Date(2025, 0, 2), 11),
-  ]);
-  calendar.normalizeDays([
     new Day(new Date(2025, 0, 1), 2),
     new Day(new Date(2024, 11, 31), 1),
     new Day(new Date(2025, 0, 5), 5),

--- a/src/model/Calendar.ts
+++ b/src/model/Calendar.ts
@@ -48,10 +48,10 @@ export class Calendar {
   // See “GitHub contribution order” in class docs.
   gitHubFirstFullyLoadedEpochDay: number = EPOCH_DAY_MAX;
 
+  // The `days` parameter is a convenience for tests.
   constructor(name: string, days: Day[] = []) {
     this.name = name;
-    // FIXME this path is now only really used by tests:
-    this.normalizeDays(days);
+    this.#normalizeDays(days);
   }
 
   /**
@@ -73,7 +73,6 @@ export class Calendar {
     );
     firstSunday.setDate(firstSunday.getDate() - firstSunday.getDay());
 
-    // No need to run normalizeDays():
     const calendar = new Calendar(name);
     calendar.days = Array.from(
       { length: 1 + toEpochDays(lastSaturday) - toEpochDays(firstSunday) },
@@ -133,7 +132,7 @@ export class Calendar {
         // accepting them here would double-count with the adjacent chunk that
         // actually owns those days.
         if (day && day.contributionCount !== null) {
-          return this.repoDayForDay(day, repository);
+          return this.#repoDayForDay(day, repository);
         }
       }
 
@@ -361,36 +360,24 @@ export class Calendar {
   }
 
   /**
-   * Gets the `RepositoryDay` for a given time and repository, creating the day
-   * if it doesn't exist.
-   */
-  repoDay(time: Date, repositorySource: RepositorySource): RepositoryDay {
-    return this.repoDayForDay(this.day(time), repositorySource);
-  }
-
-  /**
-   * Gets the `RepositoryDay` for a given time and repository, or `null` if
-   * the date falls outside the calendar's current range.
+   * Gets the `RepositoryDay` for a given time and repository.
    *
-   * Unlike `repoDay()`, this never creates new days. Use this for specific
-   * event data (commits, issues, etc.) so that events outside the summary
-   * date range are silently dropped rather than extending the calendar.
+   * Returns `undefined` if the day isn’t in the calendar.
    */
-  existingRepoDay(
-    time: Date,
-    repositorySource: RepositorySource,
-  ): RepositoryDay | null {
-    const day = this.days[this.epochDayToIndex(toEpochDays(time)) ?? -1];
-    if (!day) {
-      return null;
+  repoDay(time: Date, source: RepositorySource): RepositoryDay | undefined {
+    const day = this.day(time);
+    if (day === undefined) {
+      return undefined;
     }
-    return this.repoDayForDay(day, repositorySource);
+    return this.#repoDayForDay(day, source);
   }
 
   /**
    * Get the `RepositoryDay` for a given `Day` and repo.
+   *
+   * Creates the `RepositoryDay` if necessary.
    */
-  repoDayForDay(day: Day, repositorySource: RepositorySource): RepositoryDay {
+  #repoDayForDay(day: Day, repositorySource: RepositorySource): RepositoryDay {
     const repository = this.internRepository(repositorySource);
     let repoDay = day.repositories.get(repository.url);
     if (!repoDay) {
@@ -401,52 +388,12 @@ export class Calendar {
   }
 
   /**
-   * Gets the Day for a given localtime date, creating it if needed.
+   * Gets the `Day` for a given localtime date.
    *
-   * Maintains the invariant that `days[0]` is always a Sunday.
+   * Returns `undefined` if the day isn’t in the calendar.
    */
-  day(requestedDate: Date): Day {
-    // FIXME assumes date is midnight local time.
-    const requestedEpochDay = toEpochDays(requestedDate);
-
-    let firstEpochDay = requestedEpochDay;
-    if (this.days.length != 0) {
-      firstEpochDay = this.days[0].epochDay();
-    }
-
-    // If this.days is empty the following block will handle it.
-    const relativeDay = requestedEpochDay - firstEpochDay;
-    if (relativeDay >= this.days.length) {
-      // endPadding makes sure this.days ends on a Saturday:
-      const endPadding = 6 - requestedDate.getDay();
-      for (let i = this.days.length - relativeDay; i <= endPadding; i++) {
-        this.days.push(new Day(plusDays(requestedDate, i)));
-      }
-    }
-
-    if (relativeDay >= 0) {
-      return this.days[relativeDay];
-    }
-
-    // There are existing days, and the requested date is before the first one.
-    // Make a prefix array to prepend.
-
-    // Pad prefix to start with Sunday (date - date.getDay())
-    const prefix = [];
-    for (let i = -requestedDate.getDay(); i < 0; i++) {
-      prefix.push(new Day(plusDays(requestedDate, i)));
-    }
-    const returnDay = new Day(new Date(requestedDate));
-    prefix.push(returnDay);
-
-    // Fill gap between date and firstDate.
-    const gap = firstEpochDay - requestedEpochDay;
-    for (let i = 1; i < gap; i++) {
-      prefix.push(new Day(plusDays(requestedDate, i)));
-    }
-
-    this.days.unshift(...prefix);
-    return returnDay;
+  day(requestedDate: Date): Day | undefined {
+    return this.days[this.epochDayToIndex(toEpochDays(requestedDate)) ?? -1];
   }
 
   /**
@@ -454,8 +401,10 @@ export class Calendar {
    *
    * For existing days, only `contributionCounts` will be changed. For new days,
    * the `Day` object is inserted into the `Calendar`.
+   *
+   * Only used by tests.
    */
-  normalizeDays(newDays: Day[]) {
+  #normalizeDays(newDays: Day[]) {
     if (newDays.length === 0) {
       return;
     }


### PR DESCRIPTION
`Calendar.day` is only really used by tests. This radically simplifies
it by removing its ability to create `Day`s, so it is now only used to
access a `Day` by date.

This also removes the unused `Calendar.existingRepoDay` and makes
`Calendar.normalizeDays` and `Calendar.repoDayForDay` private.

This removes a bunch of tests related to calendar modification and
`normalizeDays`, since we now expect calendar ranges to be pre-declared,
and `normalizeDays` will be simplified in a future change (it’s only
used for testing).
